### PR TITLE
Update release workflow to publish to TestPyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,10 +159,12 @@ jobs:
           path: dist/
           retention-days: 30
 
-      - name: Publish to PyPI
+      - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+
 
       - name: Configure git for release
         run: |


### PR DESCRIPTION
This PR updates the release workflow to publish packages to TestPyPI instead of the main PyPI repository.

**Changes:**
- Changed the PyPI publish step to use TestPyPI repository
- Added repository-url parameter pointing to test.pypi.org
- This helps test releases before publishing to the main PyPI repository

**Benefits:**
- Safer release testing process
- Ability to validate packages before main PyPI publication
- Reduces risk of publishing broken releases to production PyPI