### PR TITLE
Add 10-minute timeout to Playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   playwright-e2e-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     defaults:
       run:


### PR DESCRIPTION
Add timeout-minutes: 10 to prevent E2E tests from running indefinitely