### PR TITLE
Switch to production PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,6 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     needs: [release, ts-tests, pre-commit-checks, e2e-tests]
-    environment: testpypi
     env:
       VERSION: ${{ needs.release.outputs.version }}
     permissions:
@@ -134,16 +133,15 @@ jobs:
           path: dist/
           retention-days: 30
 
-      - name: Publish to TestPyPI #This is a test PyPI server, not the real one
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist/
-          repository-url: https://test.pypi.org/legacy/
           verbose: true
 
       - name: Set PyPI URL for notifications
         run: |
-          echo "PYPI_URL=https://test.pypi.org/project/streamlit-pdf/$VERSION/" >> $GITHUB_ENV
+          echo "PYPI_URL=https://pypi.org/project/streamlit-pdf/$VERSION/" >> $GITHUB_ENV
 
 
       - name: Configure git for release
@@ -201,7 +199,7 @@ jobs:
                   \"fields\": [
                     {
                       \"type\": \"mrkdwn\",
-                      \"text\": \"*TestPyPI:*\n<$PYPI_URL|View on TestPyPI>\"
+                      \"text\": \"*PyPI:*\n<$PYPI_URL|View on PyPI>\"
                     },
                     {
                       \"type\": \"mrkdwn\",
@@ -255,7 +253,7 @@ jobs:
           echo "🎉 Release v$VERSION completed successfully!"
           echo ""
           echo "📦 Artifacts:"
-          echo "  - TestPyPI: https://test.pypi.org/project/streamlit-pdf/$VERSION/"
+          echo "  - PyPI: https://pypi.org/project/streamlit-pdf/$VERSION/"
           echo "  - GitHub: https://github.com/${{ github.repository }}/releases/tag/v$VERSION"
           echo ""
           echo "🔗 Links:"


### PR DESCRIPTION
Switch release workflow from TestPyPI to production PyPI

- Remove repository-url to use default PyPI
- Update all URLs and notifications to reference PyPI