### PR TITLE
[fix] PDF media urls should utilize streamlitUrl if present

### DIFF
--- a/streamlit_pdf/frontend/package.json
+++ b/streamlit_pdf/frontend/package.json
@@ -16,7 +16,7 @@
     "start": "vite",
     "build": "tsc && vite build",
     "format": "prettier --write src/**/*.tsx",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage"
   },

--- a/streamlit_pdf/frontend/src/PdfViewer.tsx
+++ b/streamlit_pdf/frontend/src/PdfViewer.tsx
@@ -32,6 +32,7 @@ import { flushSync } from "react-dom"
 import { Document, Page, pdfjs } from "react-pdf"
 import { useVirtualizer } from "@tanstack/react-virtual"
 import styles from "./PdfViewer.module.css"
+import { mergeFileUrlWithStreamlitUrl } from "./urlUtils"
 
 // Configure PDF.js worker to use local file
 // In Streamlit components, files are served from the same origin
@@ -66,7 +67,9 @@ const PAGE_MARGIN = 12
  * @returns {ReactElement} The rendered PDF viewer component
  */
 function PDFViewer({ args, theme }: ComponentProps): ReactElement {
-  const { file, height = 600 } = args
+  const { file: baseFileUrl, height = 600 } = args
+
+  const file = mergeFileUrlWithStreamlitUrl(baseFileUrl)
 
   const [numPages, setNumPages] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(true)

--- a/streamlit_pdf/frontend/src/PdfViewer.tsx
+++ b/streamlit_pdf/frontend/src/PdfViewer.tsx
@@ -67,9 +67,9 @@ const PAGE_MARGIN = 12
  * @returns {ReactElement} The rendered PDF viewer component
  */
 function PDFViewer({ args, theme }: ComponentProps): ReactElement {
-  const { file: baseFileUrl, height = 600 } = args
+  const { file: fileUrl, height = 600 } = args
 
-  const file = mergeFileUrlWithStreamlitUrl(baseFileUrl)
+  const file = mergeFileUrlWithStreamlitUrl(fileUrl)
 
   const [numPages, setNumPages] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(true)

--- a/streamlit_pdf/frontend/src/urlUtils.test.tsx
+++ b/streamlit_pdf/frontend/src/urlUtils.test.tsx
@@ -106,4 +106,45 @@ describe("mergeFileUrlWithStreamlitUrl", () => {
       )
     })
   })
+
+  describe("with encoded streamlitUrl from Community Cloud in query", () => {
+    beforeEach(() => {
+      const encoded =
+        "streamlitUrl=https%3A%2F%2Fst-pdf.streamlit.app%2F~%2F%2B%2F"
+      setSearch(encoded)
+    })
+
+    it("decodes and merges correctly", () => {
+      expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+        "https://st-pdf.streamlit.app/~/+/media/file.pdf"
+      )
+    })
+  })
+
+  describe("Multipage apps locally", () => {
+    beforeEach(() => {
+      const encoded = "streamlitUrl=http%3A%2F%2Flocalhost%3A8501%2FPDF_Viewer"
+      setSearch(encoded)
+    })
+
+    it("decodes and merges correctly", () => {
+      expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+        "http://localhost:8501/media/file.pdf"
+      )
+    })
+  })
+
+  describe("Multipage apps in Community Cloud", () => {
+    beforeEach(() => {
+      const encoded =
+        "streamlitUrl=https%3A%2F%2Fst-pdf.streamlit.app%2F~%2F%2B%2FPDF_Viewer"
+      setSearch(encoded)
+    })
+
+    it("decodes and merges correctly", () => {
+      expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+        "https://st-pdf.streamlit.app/~/+/media/file.pdf"
+      )
+    })
+  })
 })

--- a/streamlit_pdf/frontend/src/urlUtils.test.tsx
+++ b/streamlit_pdf/frontend/src/urlUtils.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { mergeFileUrlWithStreamlitUrl } from "./urlUtils"
+
+const setSearch = (search: string) => {
+  const url = search ? (search.startsWith("?") ? search : `?${search}`) : "/"
+  window.history.replaceState({}, "", url)
+}
+
+describe("mergeFileUrlWithStreamlitUrl", () => {
+  beforeEach(() => {
+    setSearch("")
+  })
+
+  it("returns URL as-is when not under /media", () => {
+    setSearch("streamlitUrl=http://localhost:8501")
+
+    const urls = [
+      "https://example.com/file.pdf",
+      "http://example.com/file.pdf",
+      "//cdn.example.com/file.pdf",
+      "/static/file.pdf",
+      "images/file.pdf",
+      "media/file.pdf",
+      "/media",
+      "data:application/pdf;base64,AAA",
+      "blob:https://example.com/123",
+    ]
+
+    for (const u of urls) {
+      expect(mergeFileUrlWithStreamlitUrl(u)).toBe(u)
+    }
+  })
+
+  it("returns URL as-is when no streamlitUrl present (no query)", () => {
+    const fileUrl = "/media/file.pdf"
+    expect(mergeFileUrlWithStreamlitUrl(fileUrl)).toBe(fileUrl)
+  })
+
+  it("returns URL as-is when query exists but streamlitUrl missing", () => {
+    setSearch("foo=bar&baz=1")
+    const fileUrl = "/media/file.pdf"
+    expect(mergeFileUrlWithStreamlitUrl(fileUrl)).toBe(fileUrl)
+  })
+
+  it("merges base without trailing slash and media path", () => {
+    setSearch("streamlitUrl=http://localhost:8501")
+    expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+      "http://localhost:8501/media/file.pdf"
+    )
+  })
+
+  it("normalizes trailing slash on base URL", () => {
+    setSearch("streamlitUrl=http://localhost:8501/")
+    expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+      "http://localhost:8501/media/file.pdf"
+    )
+  })
+
+  it("normalizes multiple trailing slashes on base URL", () => {
+    setSearch("streamlitUrl=http://localhost:8501///")
+    expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+      "http://localhost:8501/media/file.pdf"
+    )
+  })
+
+  it("normalizes multiple leading slashes on media path", () => {
+    setSearch("streamlitUrl=http://localhost:8501")
+    expect(mergeFileUrlWithStreamlitUrl("///media/file.pdf")).toBe(
+      "http://localhost:8501/media/file.pdf"
+    )
+  })
+
+  it("preserves nested media subpaths", () => {
+    setSearch("streamlitUrl=http://localhost:8501")
+    expect(mergeFileUrlWithStreamlitUrl("/media/sub/dir/file.pdf")).toBe(
+      "http://localhost:8501/media/sub/dir/file.pdf"
+    )
+  })
+
+  it("accepts encoded streamlitUrl parameter", () => {
+    const encoded = "streamlitUrl=http%3A%2F%2Flocalhost%3A8501%2F"
+    setSearch(encoded)
+    expect(mergeFileUrlWithStreamlitUrl("/media/file.pdf")).toBe(
+      "http://localhost:8501/media/file.pdf"
+    )
+  })
+})

--- a/streamlit_pdf/frontend/src/urlUtils.ts
+++ b/streamlit_pdf/frontend/src/urlUtils.ts
@@ -45,6 +45,29 @@ const getStreamlitUrl = () => {
   return streamlitUrl || null
 }
 
+/**
+ * Merges a Streamlit-served media path with the Streamlit app base URL from the
+ * current page's query string (the `streamlitUrl` parameter).
+ *
+ * Behavior:
+ * - If `fileUrl` is `undefined`, returns `undefined`.
+ * - If `fileUrl` does not start with `/media/` (after collapsing any leading
+ *   slashes), returns `fileUrl` unchanged.
+ * - If no `streamlitUrl` query parameter is present, returns `fileUrl`
+ *   unchanged.
+ * - When merging, trailing slashes are trimmed from the base URL and leading
+ *   slashes from the media path to avoid duplicate slashes.
+ * - Inputs like `///media/file.pdf` are normalized and treated as media paths.
+ *
+ * Example:
+ * - Given `?streamlitUrl=http://localhost:8501`,
+ *   `mergeFileUrlWithStreamlitUrl("/media/file.pdf")` →
+ *   `http://localhost:8501/media/file.pdf`.
+ * - `mergeFileUrlWithStreamlitUrl("https://example.com/file.pdf")` → unchanged.
+ *
+ * @param fileUrl The input file URL or path. May be absolute or a `/media/`-relative path.
+ * @returns The merged absolute URL when applicable, otherwise the original `fileUrl` (or `undefined`).
+ */
 export const mergeFileUrlWithStreamlitUrl = (fileUrl: string | undefined) => {
   if (!fileUrl) {
     return undefined

--- a/streamlit_pdf/frontend/src/urlUtils.ts
+++ b/streamlit_pdf/frontend/src/urlUtils.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2025 Snowflake Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This should match the value of `MEDIA_ENDPOINT` in the Streamlit repo with an
+ * added `/` at the end.
+ * @see `lib/streamlit/web/server/server.py`
+ */
+const BASE_MEDIA_PATH = "/media/"
+
+/**
+ * For Custom Components v1, the Streamlit URL is passed as a query parameter in
+ * the URL for the iframe.
+ *
+ * @returns The Streamlit URL or null if not found
+ */
+const getStreamlitUrl = () => {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  const search = window.location.search
+
+  if (!search) {
+    return null
+  }
+
+  const params = new URLSearchParams(search)
+  const streamlitUrl = params.get("streamlitUrl")
+
+  return streamlitUrl || null
+}
+
+export const mergeFileUrlWithStreamlitUrl = (fileUrl: string | undefined) => {
+  if (!fileUrl) {
+    return undefined
+  }
+
+  // Normalize multiple leading slashes so inputs like "///media/..." are treated as media URLs
+  const normalizedFileUrl = fileUrl.replace(/^\/+/, "/")
+
+  if (!normalizedFileUrl.startsWith(BASE_MEDIA_PATH)) {
+    // If the file URL is not a relative media URL, return it as is since it is
+    // likely an external URL.
+    return fileUrl
+  }
+
+  const streamlitUrl = getStreamlitUrl()
+
+  if (!streamlitUrl) {
+    return fileUrl
+  }
+
+  const base = streamlitUrl.replace(/\/+$/, "")
+  const path = normalizedFileUrl.replace(/^\/+/, "")
+  return `${base}/${path}`
+}

--- a/streamlit_pdf/frontend/src/urlUtils.ts
+++ b/streamlit_pdf/frontend/src/urlUtils.ts
@@ -49,21 +49,40 @@ const getStreamlitUrl = () => {
  * Merges a Streamlit-served media path with the Streamlit app base URL from the
  * current page's query string (the `streamlitUrl` parameter).
  *
+ * Why this is important:
+ * - Streamlit serves media from an app-level endpoint, not a page-level path.
+ *   In multipage apps the `streamlitUrl` may include the active page slug
+ *   (e.g., `/Some_Page`). Naively appending `/media/...` produces
+ *   `/Some_Page/media/...`, which does not exist. We anchor media at the app
+ *   base by trimming only the last segment when needed, so URLs remain valid
+ *   regardless of the current page.
+ * - The function is resilient to odd inputs (extra slashes) and does not alter
+ *   absolute/external URLs.
+ *
  * Behavior:
  * - If `fileUrl` is `undefined`, returns `undefined`.
  * - If `fileUrl` does not start with `/media/` (after collapsing any leading
  *   slashes), returns `fileUrl` unchanged.
  * - If no `streamlitUrl` query parameter is present, returns `fileUrl`
  *   unchanged.
- * - When merging, trailing slashes are trimmed from the base URL and leading
- *   slashes from the media path to avoid duplicate slashes.
+ * - When merging, the function:
+ *   - Parses the `streamlitUrl`.
+ *   - Derives an app base path from its pathname:
+ *     - If the pathname ends with `/`, use it as-is.
+ *     - Otherwise, drop the last path segment (e.g., a multipage slug) and keep
+ *       the prefix.
+ *   - Normalizes the base path by collapsing duplicate slashes and ensuring a
+ *     single leading slash and a trailing slash (except when the base is just `/`).
+ *   - Joins `${origin}${basePath}` with the normalized media path to form the
+ *     absolute media URL.
  * - Inputs like `///media/file.pdf` are normalized and treated as media paths.
  *
- * Example:
- * - Given `?streamlitUrl=http://localhost:8501`,
- *   `mergeFileUrlWithStreamlitUrl("/media/file.pdf")` →
+ * Examples:
+ * - `?streamlitUrl=http://localhost:8501` + `/media/file.pdf` →
  *   `http://localhost:8501/media/file.pdf`.
- * - `mergeFileUrlWithStreamlitUrl("https://example.com/file.pdf")` → unchanged.
+ * - `?streamlitUrl=http://localhost:8501/Some_Page` + `/media/file.pdf` →
+ *   `http://localhost:8501/media/file.pdf` (drops the page segment).
+ * - `mergeFileUrlWithStreamlitUrl("https://cdn.example.com/file.pdf")` → unchanged.
  *
  * @param fileUrl The input file URL or path. May be absolute or a `/media/`-relative path.
  * @returns The merged absolute URL when applicable, otherwise the original `fileUrl` (or `undefined`).
@@ -88,7 +107,43 @@ export const mergeFileUrlWithStreamlitUrl = (fileUrl: string | undefined) => {
     return fileUrl
   }
 
-  const base = streamlitUrl.replace(/\/+$/, "")
-  const path = normalizedFileUrl.replace(/^\/+/, "")
-  return `${base}/${path}`
+  try {
+    const url = new URL(streamlitUrl)
+
+    // Derive the app base solely from the Streamlit URL's pathname.
+    // - If pathname ends with '/', it's already the base.
+    // - Otherwise, drop the last segment (page slug) and keep the prefix.
+    const parentPath = url.pathname || "/"
+    let appBasePath: string
+    if (parentPath.endsWith("/")) {
+      appBasePath = parentPath
+    } else {
+      const lastSlash = parentPath.lastIndexOf("/")
+      appBasePath = parentPath.slice(0, Math.max(0, lastSlash + 1))
+      if (!appBasePath) {
+        appBasePath = "/"
+      }
+    }
+
+    // Normalize base path: collapse multiple slashes, ensure single leading and
+    // trailing slash (except root which is just "/").
+    appBasePath = appBasePath.replace(/\/{2,}/g, "/")
+    if (!appBasePath.startsWith("/")) {
+      appBasePath = `/${appBasePath}`
+    }
+    if (appBasePath !== "/" && !appBasePath.endsWith("/")) {
+      appBasePath = `${appBasePath}/`
+    }
+
+    const origin = url.origin
+    const mediaPath = normalizedFileUrl.replace(/^\/+/, "")
+    const baseWithTrailingSlash = appBasePath
+
+    return `${origin}${baseWithTrailingSlash}${mediaPath}`
+  } catch {
+    // Fallback: Simple replacement
+    const base = streamlitUrl.replace(/\/+$/, "")
+    const path = normalizedFileUrl.replace(/^\/+/, "")
+    return `${base}/${path}`
+  }
 }


### PR DESCRIPTION
- There is an issue when running `st.pdf` in Community Cloud when attempting to render an uploaded PDF.
- `streamlit-pdf` was not properly utilizing the `streamlitUrl` given to it in the search param, leading to an incorrect URL being generated, which led to the PDF not rendering at all.
- This PR reads the `streamlitUrl` and if it exists, constructs the correct path.
  - In order to maintain support for rendering PDFs from URLs, we check against `BASE_MEDIA_PATH`, which matches what is in the Streamlit server code `lib/streamlit/web/server/server.py`

To test this, go to https://st-pdf.streamlit.app/ and upload a PDF. It should now work.

Fixes https://github.com/streamlit/streamlit-pdf/issues/19