### PR TITLE
Add support for bare execution mode

### DIFF
--- a/streamlit_pdf/__init__.py
+++ b/streamlit_pdf/__init__.py
@@ -197,11 +197,13 @@ def _process_file_input(
             raise RuntimeError(f"Cannot process provided data of type: {type(file)}")
 
         # Add to media file manager
-        from streamlit.runtime import Runtime
+        from streamlit import runtime
 
-        runtime = Runtime.instance()
-        pdf_url = runtime.media_file_mgr.add(
-            data_or_filename, "application/pdf", coordinates
-        )
+        if runtime.exists():
+            pdf_url = runtime.get_instance().media_file_mgr.add(
+                data_or_filename, "application/pdf", coordinates
+            )
+            return pdf_url
 
-        return pdf_url
+        # When running in "bare execution", we can't access the MediaFileManager.
+        return ""


### PR DESCRIPTION
Fixing the `streamlit-pdf` component to work with the bare execution mode. Bare execution means running Streamlit scripts without Streamlit runtime.